### PR TITLE
Pass a context to the evaluator

### DIFF
--- a/lib/buff/config/ruby.rb
+++ b/lib/buff/config/ruby.rb
@@ -8,16 +8,18 @@ module Buff
           # Parse the contents of the Ruby file into a Hash.
           #
           # @param [String] contents
+          # @param [Object] caller the parent Config object
           #
           # @return [Hash]
-          def parse(contents,ctx=nil)
-            self.new(contents,ctx).send(:attributes)
+          def parse(contents, caller=nil)
+            self.new(contents, caller).send(:attributes)
           end
         end
 
         # @param [String] contents
-        def initialize(contents,ctx=nil)
-          @ctx = ctx
+        # @param [Object] caller
+        def initialize(contents, caller=nil)
+          @caller = caller
           @attributes = Hash.new
           instance_eval(contents)
         rescue Exception => ex
@@ -32,8 +34,8 @@ module Buff
         def method_missing(m, *args, &block)
           if args.size > 0
             attributes[m.to_sym] = (args.length == 1) ? args[0] : args
-          elsif @ctx && @ctx.respond_to?(m)
-            @ctx.send(m, *args, &block)
+          elsif @caller && @caller.respond_to?(m)
+            @caller.send(m, *args, &block)
           else
             super
           end
@@ -103,7 +105,7 @@ module Buff
       #
       # @return [Buff::Config::Ruby]
       def from_ruby(contents)
-        hash = Buff::Config::Ruby::Evaluator.parse(contents,self)
+        hash = Buff::Config::Ruby::Evaluator.parse(contents, self)
         mass_assign(hash)
         self
       end

--- a/lib/buff/config/ruby.rb
+++ b/lib/buff/config/ruby.rb
@@ -10,13 +10,14 @@ module Buff
           # @param [String] contents
           #
           # @return [Hash]
-          def parse(contents)
-            self.new(contents).send(:attributes)
+          def parse(contents,ctx=nil)
+            self.new(contents,ctx).send(:attributes)
           end
         end
 
         # @param [String] contents
-        def initialize(contents)
+        def initialize(contents,ctx=nil)
+          @ctx = ctx
           @attributes = Hash.new
           instance_eval(contents)
         rescue Exception => ex
@@ -31,6 +32,8 @@ module Buff
         def method_missing(m, *args, &block)
           if args.size > 0
             attributes[m.to_sym] = (args.length == 1) ? args[0] : args
+          elsif @ctx && @ctx.respond_to?(m)
+            @ctx.send(m, *args, &block)
           else
             super
           end
@@ -100,7 +103,7 @@ module Buff
       #
       # @return [Buff::Config::Ruby]
       def from_ruby(contents)
-        hash = Buff::Config::Ruby::Evaluator.parse(contents)
+        hash = Buff::Config::Ruby::Evaluator.parse(contents,self)
         mass_assign(hash)
         self
       end

--- a/lib/buff/config/ruby.rb
+++ b/lib/buff/config/ruby.rb
@@ -8,18 +8,18 @@ module Buff
           # Parse the contents of the Ruby file into a Hash.
           #
           # @param [String] contents
-          # @param [Object] caller the parent Config object
+          # @param [Object] context the parent Config object
           #
           # @return [Hash]
-          def parse(contents, caller=nil)
-            self.new(contents, caller).send(:attributes)
+          def parse(contents, context=nil)
+            self.new(contents, context).send(:attributes)
           end
         end
 
         # @param [String] contents
-        # @param [Object] caller
-        def initialize(contents, caller=nil)
-          @caller = caller
+        # @param [Object] context
+        def initialize(contents, context=nil)
+          @context = context
           @attributes = Hash.new
           instance_eval(contents)
         rescue Exception => ex
@@ -34,8 +34,8 @@ module Buff
         def method_missing(m, *args, &block)
           if args.size > 0
             attributes[m.to_sym] = (args.length == 1) ? args[0] : args
-          elsif @caller && @caller.respond_to?(m)
-            @caller.send(m, *args, &block)
+          elsif @context && @context.respond_to?(m)
+            @context.send(m, *args, &block)
           else
             super
           end

--- a/spec/buff/config/ruby_spec.rb
+++ b/spec/buff/config/ruby_spec.rb
@@ -7,6 +7,7 @@ describe Buff::Config::Ruby do
       log_level       :info
       log_location    STDOUT
       cookbook_path   ['cookbooks']
+      knife[:foo] = 'bar'
     )
   end
 
@@ -16,6 +17,7 @@ describe Buff::Config::Ruby do
       attribute :log_location
       attribute :node_name, default: 'bacon'
       attribute :cookbook_path
+      attribute :knife, default: {}
     end
   end
 
@@ -34,6 +36,7 @@ describe Buff::Config::Ruby do
         expect(config[:log_location]).to eq(STDOUT)
         expect(config[:node_name]).to eq('bacon')
         expect(config[:cookbook_path]).to eq(['cookbooks'])
+        expect(config[:knife][:foo]).to eq('bar')
       end
     end
 


### PR DESCRIPTION
When evaling ruby config, pass the original caller in to be checked in `method_missing`.

Fixes RiotGames/ridley#202
Fixes RiotGames/buff-config#4
