### PR TITLE
unknown config keys will be ignored when parsing ruby configs

### DIFF
--- a/lib/buff/config/ruby.rb
+++ b/lib/buff/config/ruby.rb
@@ -35,19 +35,25 @@ module Buff
           Buff::Config::Ruby.platform_specific_path(path)
         end
 
-        def method_missing(m, *args, &block)
-          if args.size > 0
-            attributes[m.to_sym] = (args.length == 1) ? args[0] : args
-          elsif @context && @context.respond_to?(m)
-            @context.send(m, *args, &block)
-          else
-            super
-          end
-        end
-
         private
 
           attr_reader :attributes
+
+          def method_missing(m, *args, &block)
+            if args.size > 0
+              attributes[m.to_sym] = (args.length == 1) ? args[0] : args
+            elsif @context && @context.respond_to?(m)
+              @context.send(m, *args, &block)
+            else
+              Proxy.new
+            end
+          end
+
+          class Proxy
+            def method_missing(m, *args, &block)
+              self
+            end
+          end
       end
 
       class << self


### PR DESCRIPTION
This will stop unknown keys, such as additional keys found in a knife file, from being processed and crashing the config evalutor
